### PR TITLE
fix allocated memory misalignment

### DIFF
--- a/arena.go
+++ b/arena.go
@@ -9,7 +9,8 @@ import (
 // Arena is an interface that describes a memory allocation arena.
 type Arena interface {
 	// Alloc allocates memory of the given size and returns a pointer to it.
-	Alloc(size int) unsafe.Pointer
+	// The alignment parameter specifies the alignment of the allocated memory.
+	Alloc(size, alignment uintptr) unsafe.Pointer
 
 	// Reset resets the arena's state, optionally releasing the memory.
 	// After invoking this method any pointer previously returned by Alloc becomes immediately invalid.
@@ -22,7 +23,7 @@ type Arena interface {
 func New[T any](a Arena) *T {
 	if a != nil {
 		var x T
-		if ptr := a.Alloc(int(unsafe.Sizeof(x))); ptr != nil {
+		if ptr := a.Alloc(unsafe.Sizeof(x), unsafe.Alignof(x)); ptr != nil {
 			return (*T)(ptr)
 		}
 	}
@@ -37,7 +38,7 @@ func MakeSlice[T any](a Arena, len, cap int) []T {
 	if a != nil {
 		var x T
 		bufSize := int(unsafe.Sizeof(x)) * cap
-		if ptr := (*T)(a.Alloc(bufSize)); ptr != nil {
+		if ptr := (*T)(a.Alloc(uintptr(bufSize), unsafe.Alignof(x))); ptr != nil {
 			s := unsafe.Slice(ptr, cap)
 			return s[:len]
 		}

--- a/concurrent_arena.go
+++ b/concurrent_arena.go
@@ -19,9 +19,9 @@ func NewConcurrentArena(a Arena) Arena {
 }
 
 // Alloc satisfies the Arena interface.
-func (a *concurrentArena) Alloc(size int) unsafe.Pointer {
+func (a *concurrentArena) Alloc(size, alignment uintptr) unsafe.Pointer {
 	a.mtx.Lock()
-	ptr := a.a.Alloc(size)
+	ptr := a.a.Alloc(size, alignment)
 	a.mtx.Unlock()
 	return ptr
 }

--- a/monotonic_arena_test.go
+++ b/monotonic_arena_test.go
@@ -83,6 +83,16 @@ func TestMonotonicArenaReset(t *testing.T) {
 	_ = New[int](arena)
 }
 
+func TestMonotonicArenaMultipleTypes(t *testing.T) {
+	arena := NewMonotonicArena(8182, 1) // 8KB
+
+	var b = New[byte](arena)
+	var p = New[*int](arena)
+
+	require.Equal(t, *b, byte(0))
+	require.True(t, *p == nil)
+}
+
 func isMonotonicArenaPtr(a Arena, ptr unsafe.Pointer) bool {
 	ma := a.(*monotonicArena)
 	for _, s := range ma.buffers {
@@ -90,7 +100,7 @@ func isMonotonicArenaPtr(a Arena, ptr unsafe.Pointer) bool {
 			break
 		}
 		beginPtr := uintptr(s.ptr)
-		endPtr := uintptr(s.ptr) + uintptr(s.size)
+		endPtr := uintptr(s.ptr) + s.size
 
 		if uintptr(ptr) >= beginPtr && uintptr(ptr) < endPtr {
 			return true
@@ -114,7 +124,7 @@ func BenchmarkRuntimeNewObject(b *testing.B) {
 }
 
 func BenchmarkMonotonicArenaNewObject(b *testing.B) {
-	monotonicArena := NewMonotonicArena(1024*1024, 128) // 1Mb buffer size (128 MB)
+	monotonicArena := NewMonotonicArena(2*1024*1024, 32) // 2Mb buffer size (64Mb max size)
 
 	a := newArenaAllocator[int](monotonicArena)
 	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {
@@ -131,7 +141,7 @@ func BenchmarkMonotonicArenaNewObject(b *testing.B) {
 }
 
 func BenchmarkConcurrentMonotonicArenaNewObject(b *testing.B) {
-	monotonicArena := NewMonotonicArena(1024*1024, 128) // 1Mb buffer size (128 MB)
+	monotonicArena := NewMonotonicArena(2*1024*1024, 32) // 2Mb buffer size (64Mb max size)
 
 	a := newArenaAllocator[int](NewConcurrentArena(monotonicArena))
 	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {
@@ -162,7 +172,7 @@ func BenchmarkRuntimeMakeSlice(b *testing.B) {
 }
 
 func BenchmarkMonotonicArenaMakeSlice(b *testing.B) {
-	monotonicArena := NewMonotonicArena(1024*1024, 128) // 1Mb buffer size (128 MB)
+	monotonicArena := NewMonotonicArena(2*1024*1024, 32) // 2Mb buffer size (64Mb max size)
 
 	a := newArenaAllocator[int](monotonicArena)
 	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {
@@ -179,7 +189,7 @@ func BenchmarkMonotonicArenaMakeSlice(b *testing.B) {
 }
 
 func BenchmarkConcurrentMonotonicArenaMakeSlice(b *testing.B) {
-	monotonicArena := NewMonotonicArena(1024*1024, 128) // 1Mb buffer size (128 MB)
+	monotonicArena := NewMonotonicArena(2*1024*1024, 32) // 2Mb buffer size (64Mb max size)
 
 	a := newArenaAllocator[int](NewConcurrentArena(monotonicArena))
 	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {

--- a/slice_test.go
+++ b/slice_test.go
@@ -13,7 +13,7 @@ import (
 // It simply allocates memory using Go's built-in make function.
 type mockArena struct{}
 
-func (m *mockArena) Alloc(size int) unsafe.Pointer {
+func (m *mockArena) Alloc(size, _ uintptr) unsafe.Pointer {
 	return unsafe.Pointer(&make([]byte, size)[0])
 }
 


### PR DESCRIPTION
This PR adds the alignment parameter to the `Alloc` method of the `Arena` interface, aiming to ensure that the pointer returned by this method is aligned with this value.

Fixes: https://github.com/ortuman/nuke/issues/16