### PR TITLE
nuke/monotoniic: reset's behavior and a little bit of improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/ortuman/nuke
 
-go 1.21.7
+go 1.21.8
 
-require github.com/stretchr/testify v1.8.4
+require github.com/stretchr/testify v1.9.0
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
+github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/monotonic_arena.go
+++ b/monotonic_arena.go
@@ -54,15 +54,7 @@ func (s *monotonicBuffer) reset(release bool) {
 }
 
 func (s *monotonicBuffer) zeroOutBuffer() {
-	b := unsafe.Slice((*byte)(s.ptr), s.size)
-
-	// This piece of code will be translated into a runtime.memclrNoHeapPointers
-	// invocation by the compiler, which is an assembler optimized implementation.
-	// Architecture specific code can be found at src/runtime/memclr_$GOARCH.s
-	// in Go source (since https://codereview.appspot.com/137880043).
-	for i := range b {
-		b[i] = 0
-	}
+	clear(unsafe.Slice((*byte)(s.ptr), s.size))
 }
 
 func (s *monotonicBuffer) availableBytes() uintptr {

--- a/monotonic_arena.go
+++ b/monotonic_arena.go
@@ -37,15 +37,7 @@ func (s *monotonicBuffer) alloc(size, alignment uintptr) (unsafe.Pointer, bool) 
 	ptr := unsafe.Pointer(uintptr(s.ptr) + s.offset + alignOffset)
 	s.offset += allocSize
 
-	// This piece of code will be translated into a runtime.memclrNoHeapPointers
-	// invocation by the compiler, which is an assembler optimized implementation.
-	// Architecture specific code can be found at src/runtime/memclr_$GOARCH.s
-	// in Go source (since https://codereview.appspot.com/137880043).
-	b := unsafe.Slice((*byte)(ptr), size)
-
-	for i := range b {
-		b[i] = 0
-	}
+	clear(unsafe.Slice((*byte)(ptr), size))
 
 	return ptr, true
 }

--- a/monotonic_arena.go
+++ b/monotonic_arena.go
@@ -26,8 +26,8 @@ func (s *monotonicBuffer) alloc(size, alignment uintptr) (unsafe.Pointer, bool) 
 		s.ptr = unsafe.Pointer(unsafe.SliceData(buf))
 	}
 	alignOffset := uintptr(0)
-	if delta := (uintptr(s.ptr) + s.offset) % alignment; delta != 0 {
-		alignOffset = delta
+	if delta := (uintptr(s.ptr) + s.offset) % alignment; delta > 0 {
+		alignOffset = alignment - delta
 	}
 	allocSize := size + alignOffset
 

--- a/monotonic_arena_test.go
+++ b/monotonic_arena_test.go
@@ -111,7 +111,7 @@ func isMonotonicArenaPtr(a Arena, ptr unsafe.Pointer) bool {
 
 func BenchmarkRuntimeNewObject(b *testing.B) {
 	a := newRuntimeAllocator[int]()
-	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {
+	for _, objectCount := range []int{100, 1_000, 10_000, 100_000, 1_000_000} {
 		b.Run(fmt.Sprintf("%d", objectCount), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -127,7 +127,7 @@ func BenchmarkMonotonicArenaNewObject(b *testing.B) {
 	monotonicArena := NewMonotonicArena(2*1024*1024, 32) // 2Mb buffer size (64Mb max size)
 
 	a := newArenaAllocator[int](monotonicArena)
-	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {
+	for _, objectCount := range []int{100, 1_000, 10_000, 100_000, 1_000_000} {
 		b.Run(fmt.Sprintf("%d", objectCount), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -144,7 +144,7 @@ func BenchmarkConcurrentMonotonicArenaNewObject(b *testing.B) {
 	monotonicArena := NewMonotonicArena(2*1024*1024, 32) // 2Mb buffer size (64Mb max size)
 
 	a := newArenaAllocator[int](NewConcurrentArena(monotonicArena))
-	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {
+	for _, objectCount := range []int{100, 1_000, 10_000, 100_000, 1_000_000} {
 		b.Run(fmt.Sprintf("%d", objectCount), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -159,7 +159,7 @@ func BenchmarkConcurrentMonotonicArenaNewObject(b *testing.B) {
 
 func BenchmarkRuntimeMakeSlice(b *testing.B) {
 	a := newRuntimeAllocator[int]()
-	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {
+	for _, objectCount := range []int{100, 1_000, 10_000, 100_000, 1_000_000} {
 		b.Run(fmt.Sprintf("%d", objectCount), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -175,7 +175,7 @@ func BenchmarkMonotonicArenaMakeSlice(b *testing.B) {
 	monotonicArena := NewMonotonicArena(2*1024*1024, 32) // 2Mb buffer size (64Mb max size)
 
 	a := newArenaAllocator[int](monotonicArena)
-	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {
+	for _, objectCount := range []int{100, 1_000, 10_000, 100_000, 1_000_000} {
 		b.Run(fmt.Sprintf("%d", objectCount), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
@@ -192,7 +192,7 @@ func BenchmarkConcurrentMonotonicArenaMakeSlice(b *testing.B) {
 	monotonicArena := NewMonotonicArena(2*1024*1024, 32) // 2Mb buffer size (64Mb max size)
 
 	a := newArenaAllocator[int](NewConcurrentArena(monotonicArena))
-	for _, objectCount := range []int{100, 1_000, 10_000, 100_000} {
+	for _, objectCount := range []int{100, 1_000, 10_000, 100_000, 1_000_000} {
 		b.Run(fmt.Sprintf("%d", objectCount), func(b *testing.B) {
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {


### PR DESCRIPTION
@ortuman Hi!

there is a little bit of improvements for current version of the nuke:
- calculating `alignOffset` without iterations;
- a reset method resets underlying memory on every call;
- preallocating memory for buffers' descriptors;
- simplifying two `for`s;
- several test cases were added (please take a look at benchmark results).

the most important changes is related to behavior of the reset method.
I guess the reset method should always reset memory and release it optionally.

in general I would like to see two separate methods like (suggestion):
- `Reset()` resets memory;
- `Free()` releases memory.

as an idea in the air, we could have only one method `Free()` (like on Go's Arena) that under the hood always resets and releases memory.

Benchmark results for the nuke latest version:
```bash
go test -bench=. ./...
goos: darwin
goarch: amd64
pkg: github.com/ortuman/nuke
cpu: Intel(R) Core(TM) i7-8559U CPU @ 2.70GHz
BenchmarkRuntimeNewObject/100-8                   914125              1297 ns/op             800 B/op        100 allocs/op
BenchmarkRuntimeNewObject/1000-8                   87066             13075 ns/op            8000 B/op       1000 allocs/op
BenchmarkRuntimeNewObject/10000-8                   8016            130695 ns/op           80000 B/op      10000 allocs/op
BenchmarkRuntimeNewObject/100000-8                   878           1288538 ns/op          800009 B/op     100000 allocs/op
BenchmarkMonotonicArenaNewObject/100-8             33520             35639 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaNewObject/1000-8            24528             49212 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaNewObject/10000-8            6745            163495 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaNewObject/100000-8            846           1353877 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaNewObject/100-8                   32326             36768 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaNewObject/1000-8                  21222             53665 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaNewObject/10000-8                  4714            233151 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaNewObject/100000-8                  598           1939938 ns/op               0 B/op          0 allocs/op
BenchmarkRuntimeMakeSlice/100-8                                    36321             33419 ns/op          204800 B/op        100 allocs/op
BenchmarkRuntimeMakeSlice/1000-8                                    3405            330008 ns/op         2048009 B/op       1000 allocs/op
BenchmarkRuntimeMakeSlice/10000-8                                    362           3354655 ns/op        20480100 B/op      10001 allocs/op
BenchmarkRuntimeMakeSlice/100000-8                                    31          35878034 ns/op        204801102 B/op    100011 allocs/op
BenchmarkMonotonicArenaMakeSlice/100-8                             27572             40248 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaMakeSlice/1000-8                            23138             48749 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaMakeSlice/10000-8                            1066           1023822 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaMakeSlice/100000-8                             26          43787002 ns/op        137691202 B/op     67232 allocs/op
BenchmarkConcurrentMonotonicArenaMakeSlice/100-8                   28334             37244 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaMakeSlice/1000-8                  20376             55866 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaMakeSlice/10000-8                  1039           1123206 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaMakeSlice/100000-8                   25          48233981 ns/op        137691197 B/op     67232 allocs/op
PASS
ok      github.com/ortuman/nuke 36.701s
```

Benchmark results for this pr:
```bash
go test -bench=. ./...
goos: darwin
goarch: amd64
pkg: github.com/ortuman/nuke
cpu: Intel(R) Core(TM) i7-8559U CPU @ 2.70GHz
BenchmarkRuntimeNewObject/100-8                   936972              1286 ns/op             800 B/op        100 allocs/op
BenchmarkRuntimeNewObject/1000-8                   91796             13433 ns/op            8000 B/op       1000 allocs/op
BenchmarkRuntimeNewObject/10000-8                   8335            131346 ns/op           80000 B/op      10000 allocs/op
BenchmarkRuntimeNewObject/100000-8                   890           1266103 ns/op          800005 B/op     100000 allocs/op
BenchmarkRuntimeNewObject/1000000-8                   80          12671721 ns/op         8000057 B/op    1000000 allocs/op
BenchmarkMonotonicArenaNewObject/100-8             34165             35619 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaNewObject/1000-8            24819             46491 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaNewObject/10000-8            7020            159810 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaNewObject/100000-8            918           1272404 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaNewObject/1000000-8            54          21980538 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaNewObject/100-8                   32769             36106 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaNewObject/1000-8                  22920             51180 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaNewObject/10000-8                  5166            207716 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaNewObject/100000-8                  664           1762064 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaNewObject/1000000-8                  45          25286030 ns/op               0 B/op          0 allocs/op
BenchmarkRuntimeMakeSlice/100-8                                    36538             32732 ns/op          204801 B/op        100 allocs/op
BenchmarkRuntimeMakeSlice/1000-8                                    3331            330120 ns/op         2048009 B/op       1000 allocs/op
BenchmarkRuntimeMakeSlice/10000-8                                    352           3387211 ns/op        20480104 B/op      10001 allocs/op
BenchmarkRuntimeMakeSlice/100000-8                                    34          33814642 ns/op        204801126 B/op    100011 allocs/op
BenchmarkRuntimeMakeSlice/1000000-8                                    4         327812672 ns/op        2048010200 B/op  1000106 allocs/op
BenchmarkMonotonicArenaMakeSlice/100-8                             30214             38373 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaMakeSlice/1000-8                            24309             48698 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaMakeSlice/10000-8                             991           1085629 ns/op               0 B/op          0 allocs/op
BenchmarkMonotonicArenaMakeSlice/100000-8                             31          35497399 ns/op        137691185 B/op     67232 allocs/op
BenchmarkMonotonicArenaMakeSlice/1000000-8                             3         416722326 ns/op        1980892256 B/op   967243 allocs/op
BenchmarkConcurrentMonotonicArenaMakeSlice/100-8                   31250             37739 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaMakeSlice/1000-8                  21745             54868 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaMakeSlice/10000-8                  1105           1017490 ns/op               0 B/op          0 allocs/op
BenchmarkConcurrentMonotonicArenaMakeSlice/100000-8                   30          40167859 ns/op        137691193 B/op     67232 allocs/op
BenchmarkConcurrentMonotonicArenaMakeSlice/1000000-8                   2         544447913 ns/op        1980891952 B/op   967240 allocs/op
PASS
ok      github.com/ortuman/nuke 50.360s
```

Benchmarks above are the best of what I can get on my machine.

if you are interested in some specific change I can split this pr.